### PR TITLE
Standings service is working, needs refactoring.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -10,25 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "nba_stats_cli",
 	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Long:  "Nba Statistics Application",
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
@@ -37,15 +24,5 @@ func Execute() {
 }
 
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.nba_stats_cli.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
-
-

--- a/cmd/standings.go
+++ b/cmd/standings.go
@@ -1,0 +1,112 @@
+/*
+Copyright © 2024 Luka Piplica piplicaluka64@gmail.com
+*/
+package cmd
+
+import (
+	"io"
+	"nba/models"
+
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// Constants for API endpoint and headers
+const (
+	apiUrl        = "https://api-basketball.p.rapidapi.com/standings?league=12&season=2023-2024"
+	apiKeyHeader  = "X-RapidAPI-Key"
+	apiHostHeader = "X-RapidAPI-Host"
+	apiKey        = "API_KEY"
+)
+
+// Handles interactions with the standings API
+type StandingsService struct {
+	URL  string
+	Body io.Reader
+}
+
+// Create a new StandingsService with default values
+func NewStandingsService() *StandingsService {
+	return &StandingsService{
+		apiUrl,
+		nil,
+	}
+}
+
+// Fetch the standings data from NBA api
+func (s *StandingsService) FetchStandings() (*models.Standings, error) {
+	req, err := http.NewRequest("GET", s.URL, s.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add(apiKeyHeader, apiKey)
+	req.Header.Add(apiHostHeader, "api-basketball.p.rapidapi.com")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var standings models.Standings
+	err = json.NewDecoder(res.Body).Decode(&standings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &standings, nil
+}
+
+// DisplayStandingsTable displays the standings in a table
+func DisplayStandingsTable(standings *models.Standings) {
+	// Display standings in table
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Position", "Conference", "Team", "W", "L", "PCT"})
+
+	for _, response := range standings.Response {
+		for _, r := range response {
+			// Extract relevant fields from each Response struct
+			position := fmt.Sprintf("%d", r.Position)
+			conference := r.Group.Name
+			team := r.Team.Name
+			wins := fmt.Sprintf("%d", r.Games.Win.Total)
+			losses := fmt.Sprintf("%d", r.Games.Lose.Total)
+			winPercentage := r.Games.Win.Percentage
+
+			// Append a slice of strings to the table
+			table.Append([]string{position, conference, team, wins, losses, winPercentage})
+		}
+	}
+
+	// Display the table
+	table.Render()
+}
+
+// standingsCmd represents the standings command
+var standingsCmd = &cobra.Command{
+	Use:   "standings",
+	Short: "View the updated standings in the NBA",
+	Long:  "Nba stat data displayed in table format",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		standingsService := NewStandingsService()
+
+		standings, err := standingsService.FetchStandings()
+		if err != nil {
+			fmt.Println("An Error Occurred: ", err)
+			return
+		}
+
+		DisplayStandingsTable(standings)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(standingsCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
-module nba_stats_cli
+module nba
 
 go 1.21.5
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 /*
-Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
+Copyright © 2024 Luka Piplica piplicaluka64@gmail.com
 */
 package main
 
-import "nba_stats_cli/cmd"
+import "nba/cmd"
 
 func main() {
 	cmd.Execute()

--- a/models/standings.go
+++ b/models/standings.go
@@ -1,0 +1,38 @@
+package models
+
+// Root JSON reposone fields
+type Standings struct {
+	Errors   []int                 `json:"errors"`
+	Response [][]StandingsResponse `json:"response"`
+}
+
+// Standings JSON repsonse fields
+type StandingsResponse struct {
+	Position int        `json:"position"`
+	Group    Conference `json:"group"`
+	Team     Team       `json:"team"`
+	Games    Games      `json:"games"`
+}
+
+// Conference JSON repsonse fields
+type Conference struct {
+	Name string `json:"name"`
+}
+
+// Team JSON repsonse fields
+type Team struct {
+	Name string `json:"name"`
+}
+
+// Games JSON response fields
+type Games struct {
+	Played int               `json:"played"`
+	Win    WinLossPercentage `json:"win"`
+	Lose   WinLossPercentage `json:"lose"`
+}
+
+// Win Loss and Percentage stats JSON response fields
+type WinLossPercentage struct {
+	Total      int    `json:"total"`
+	Percentage string `json:"percentage"`
+}


### PR DESCRIPTION
The standings command fetches NBA standings stats from the API below: 

* https://api-basketball.p.rapidapi.com/standings?league=12&season=2023-2024 
* The models for the JSON response fields from the API are in ./models/standings.go
* This CLI application also uses the https://pkg.go.dev/github.com/olekukonko/tablewriter#section-readme package for displaying all of the NBA stats in table format in the command line

TODO:

* Refractor the table output to have a separate table for each conference (East/West)